### PR TITLE
explicitly indicate 508 as a string

### DIFF
--- a/.codeinventory.yml
+++ b/.codeinventory.yml
@@ -3,7 +3,7 @@ description: 'Accessibility Playbook provides a framework for building a Section
 openSourceProject: 1
 governmentWideReuseProject: 1
 tags:
-    - 508
+    - '508'
     - accessibility
     - maturity
     - policy


### PR DESCRIPTION
YAML thinks that 508 is an integer, resulting in issues on Code.gov. Fixing this by adding quotes around 508 to indicate it's actually a string.